### PR TITLE
V0.2 : Errors will be logged on --verbose with this build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can check exit code to get number of errors, so you can write some other scr
     ./qasmine /where/jasmine/SpecRunner.html > /dev/null ; echo $?
 
 
-## Error codes
-* -1 : File not found or cannot be loaded
+## Exit codes
+* 255 : File not found or cannot be loaded
 * 0 : Success
 * > 0 : number of errors of specs

--- a/src/js/jasmine-qasmine.js
+++ b/src/js/jasmine-qasmine.js
@@ -8,7 +8,14 @@ jasmine.QasmineReporter = function(doc) {
 
     this.output = "";
 
-    this.logger = function() {};
+    this.qasmine = {};
+    this.qasmine.log = function (text) {
+	    console.log(text);
+    };
+    
+    this.qasmine.exitConditionally = function (code) {
+	    console.log('Should exit with code : ' + code);
+    };
 };
 
 
@@ -20,6 +27,10 @@ jasmine.QasmineReporter.prototype.includeJs = function (jsFile) {
     script.defer = true;
     document.getElementsByTagName('head').item(0).appendChild(script);
 };
+
+jasmine.QasmineReporter.prototype.setQasmine = function (qasmine) {
+    this.qasmine = qasmine;
+}
 
 
 jasmine.QasmineReporter.prototype.setVerbose = function (verbose) {
@@ -57,13 +68,19 @@ jasmine.QasmineReporter.prototype.reportRunnerResults = function(runner) {
             var successText = spec.success ? "OK" : "FAIL";
             var testResult = "(" + spec.total + "/" + spec.passed + ")"; 
             this.output += "\n" + successText + " | " + spec.name + testResult;
+	    
+            for(var x = 0, xx = spec.traceMessages.length; x < xx; x ++) {
+                this.output += "\n   >> " + spec.traceMessages[x];
+            }
         }
     }
+    
+    //console.log(this.output);
 
-    if(qasmine) {
-        qasmine.log(this.output);
-        qasmine.exitConditionally(failedSpecCount);
-    }
+    
+    this.qasmine.log(this.output);
+    this.qasmine.exitConditionally(failedSpecCount);
+    
 
     //console.log(this.output);
     //return this.output;
@@ -113,10 +130,22 @@ jasmine.QasmineReporter.prototype.reportSpecResults = function(spec) {
     var total = results.totalCount;
     var passed = results.passedCount;
     var failedCount = results.failedCount;
-
+    
+    var items = results.getItems();
+    
+    var traceMessages = [];
+    
+    for(var i in items) {
+	var item = items[i];
+	if(item.trace.message) {
+	  traceMessages.push(item.trace.name + " : " + item.trace.message);
+	}
+    }
+       
     var spec ={ name : this.tmpSpec,
                 total : total,
                 passed : passed,
+                traceMessages : traceMessages,
                 success : (failedCount == 0)
              };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,5 +32,5 @@ int main(int argc, char *argv[])
         return a.exec();
     }
 
-    return -1;
+    return 255;
 }

--- a/src/qasmine.cpp
+++ b/src/qasmine.cpp
@@ -101,12 +101,13 @@ QString Qasmine::getQasmineJsCommand() {
     QString executeJasmineCmd = "var qasmineReporter = new jasmine.QasmineReporter();";
 
     if (verbose == true) {
-        executeJasmineCmd        += "qasmineReporter.setVerbose(true);";
+        executeJasmineCmd    += "qasmineReporter.setVerbose(true);";
     }
     else {
-        executeJasmineCmd        += "qasmineReporter.setVerbose(false);";
+        executeJasmineCmd    += "qasmineReporter.setVerbose(false);";
     }
 
+    executeJasmineCmd        += "qasmineReporter.setQasmine(qasmine);";
     executeJasmineCmd        += "jasmine.getEnv().addReporter(qasmineReporter);";
     executeJasmineCmd        += "jasmine.getEnv().execute();";
 
@@ -121,7 +122,7 @@ void Qasmine::finishLoading(bool isFinished)
 
     if (!isFinished) {
         this->log("ERROR: cannot load file : '" + fileName + "'");
-        QApplication::instance()->exit(-1);
+        exitConditionally(255);
     }
 
     QWebFrame *frame  = webView->page()->mainFrame();


### PR DESCRIPTION
Like this : 

```
$ ./qasmine /var/www/jasmine/SpecRunner.html --verbose
5 Specs, 1 failures in 13ms
FAIL | Player should be able to play a Song(2/0)
   >> Error : Expected { persistFavoriteStatus : Function } to equal 'foo'.
   >> Error : Expected { currentlyPlayingSong : { persistFavoriteStatus : Function }, isPlaying : true, play : Function, pause : Function, resume : Function, makeFavorite : Function } to be playing 'mong'.
OK | when song has been paused should indicate that the song is currently paused(2/2)
OK | when song has been paused should be possible to resume(2/2)
OK | Player tells the current song if the user has made it a favorite(1/1)
OK | #resume should throw an exception if song is already playing(1/1)
```
